### PR TITLE
fix panic: argoRolloutsEnabled=false

### DIFF
--- a/admiral/pkg/clusters/types.go
+++ b/admiral/pkg/clusters/types.go
@@ -276,7 +276,9 @@ func (gtp *GlobalTrafficHandler) Added(obj *v1.GlobalTrafficPolicy) {
 	//IMPORTANT: The deployment/Rollout matched with a GTP will not necessarily be from the same cluster. This is because the same service could be deployed in multiple clusters and we need to guarantee consistent behavior
 	for _, remoteCluster := range gtp.RemoteRegistry.RemoteControllers {
 		matchedDeployments = append(matchedDeployments, remoteCluster.DeploymentController.GetDeploymentByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
-		matchedRollouts = append(matchedRollouts, remoteCluster.RolloutController.GetRolloutByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
+		if gtp.RemoteRegistry.AdmiralCache.argoRolloutsEnabled {
+			matchedRollouts = append(matchedRollouts, remoteCluster.RolloutController.GetRolloutByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
+		}
 	}
 
 	deployments := common.MatchDeploymentsToGTP(obj, matchedDeployments)
@@ -317,7 +319,9 @@ func (gtp *GlobalTrafficHandler) Updated(obj *v1.GlobalTrafficPolicy) {
 	//IMPORTANT: The deployment/Rollout matched with a GTP will not necessarily be from the same cluster. This is because the same service could be deployed in multiple clusters and we need to guarantee consistent behavior
 	for _, remoteCluster := range gtp.RemoteRegistry.RemoteControllers {
 		matchedDeployments = append(matchedDeployments, remoteCluster.DeploymentController.GetDeploymentByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
-		matchedRollouts = append(matchedRollouts, remoteCluster.RolloutController.GetRolloutByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
+		if gtp.RemoteRegistry.AdmiralCache.argoRolloutsEnabled {
+			matchedRollouts = append(matchedRollouts, remoteCluster.RolloutController.GetRolloutByLabel(obj.Labels[common.GetGlobalTrafficDeploymentLabel()], obj.Namespace)...)
+		}
 	}
 
 	deployments := common.MatchDeploymentsToGTP(obj, matchedDeployments)

--- a/admiral/pkg/clusters/types_test.go
+++ b/admiral/pkg/clusters/types_test.go
@@ -2,11 +2,16 @@ package clusters
 
 import (
 	"context"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	argofake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1"
+	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1"
 	admiralFake "github.com/istio-ecosystem/admiral/admiral/pkg/client/clientset/versioned/fake"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
@@ -14,10 +19,6 @@ import (
 	v13 "k8s.io/api/core/v1"
 	time2 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"log"
-	"sync"
-	"testing"
-	"time"
 )
 
 var ignoreUnexported = cmpopts.IgnoreUnexported(v1.GlobalTrafficPolicy{}.Status)
@@ -860,6 +861,7 @@ func TestGlobalTrafficHandler_Updated_ForRollouts(t *testing.T) {
 
 	admiralCacle.GlobalTrafficCache = gtpCache
 	registry.AdmiralCache = admiralCacle
+	admiralCacle.argoRolloutsEnabled = true
 	handler.RemoteRegistry = registry
 
 	e2eGtp := v1.GlobalTrafficPolicy{}


### PR DESCRIPTION
When we set param `ArgoRolloutsEnabled=false` RolloutController doesn’t get instantiated. 

But when Added/Updated function of `GlobalTrafficHandler` receiver gets called, it in turn calls `GetRolloutByLabel`. 
And since here the controller was not instantiated and no check is done Admiral panics and crashes. 

This doesn’t occur when `ArgoRolloutsEnabled=true` but when set to false admiral crashes when GlobalTrafficHandler receiver's Added/Updated function gets called. 

This PR does a check if `ArgoRolloutsEnabled` param is set true or false.